### PR TITLE
Fix: Remove hardcoded server name in gradio_server.py

### DIFF
--- a/inference/gradio_server.py
+++ b/inference/gradio_server.py
@@ -786,7 +786,6 @@ if __name__ == "__main__":
         server_port = int(os.getenv("SERVER_PORT", "7860"))
 
     # server_name = args.server_name
-    server_name = "localhost"
     if len(server_name) == 0:
         server_name = os.getenv("SERVER_NAME", "0.0.0.0")
 


### PR DESCRIPTION
The script would forcibly bind to localhost (i.e. 127.0.0.1). This prevents hosting in a Docker file. 

The code already looks up the env variable fore a host name, but ignores it. 

The fix is to remove the hardcoded binding to localhost, and allow the configuration of 0.0.0.0, so that it can be exposed to the local network, i.e. as required in Docker.

I am not sure though why we would do this via env variables, when we already use the args parser in the script. I think it would have been nicer to lat the args parser handle it. Anyways, no worries. It seems to work.